### PR TITLE
Add syntax highlighting to README. Fix some of the Rust in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,7 @@ cargo install commonregex
 
 Or use Crates.toml
 
-```
-[package]
-name = <package-name>
-version = <version>
-authors = [<you>]
-
+```toml
 [dependencies]
 commonregex = "0.1.4"
 ```
@@ -39,7 +34,7 @@ You can instantiate a CommonRegex object passing a string in the constructor and
 
 Possible properties and its equivalent methods:
 
-* dates: `dates(text)`                            
+* dates: `dates(text)`
 * times: `times(text: &str)`
 * phones: `phones(text: &str)`
 * phones_with_exts: `phones_with_exts(text: &str)`
@@ -71,31 +66,31 @@ Possible properties and its equivalent methods:
 
 Examples
 ========
-```
+```rust
 extern crate commonregex;
 
-let text = 'John, please get that article on www.linkedin.com to me by 5:00PM 
-on Jan 9th 2012. 4:00 would be ideal, actually. If you have any 
+let text = "John, please get that article on www.linkedin.com to me by 5:00PM
+on Jan 9th 2012. 4:00 would be ideal, actually. If you have any
 questions, You can reach me at (519)-236-2723x341 or get in touch with
-my associate at harold.smith@gmail.com';
+my associate at harold.smith@gmail.com";
 
 let parsed =  commonregex::CommonRegex(text);
 println!("{:?}", parsed);
 /* prints CommonRegex { dates: ["Jan 9th 2012"], times: ["5:00PM", "4:00 "], phones: ["(519)-236-2723"], phones_with_exts: ["(519)-236-2723x341"], links: ["www.linkedin.com", "harold.smith@gmail.com"], emails: ["harold.smith@gmail.com"], ipv4s: [], ipv6s: [], prices: [], hex_colors: ["201", "dea", "eac", "519", "236", "272", "341"], credit_cards: [], visas: [], mastercards: [], btc_addresses: [], street_addresses: [], zip_codes: [], po_boxs: [], ssns: [], md5s: [], sha1s: [], sha2s: [], guids: [], isbn13s: [], isbn10s: [], mac_addresses: [], ibans: [], gitrepos: [] } */
 println!("{:?}", parsed.dates);
-//prints ["Jan 9th 2012"]
+// prints ["Jan 9th 2012"]
 println!("{:?}", parsed.times);
-//prints ["5:00PM", "4:00"]
-println!("{:?}",parsed.phones);
-//prints ["(012)-345-6789"]
-println!("{:?}",parsed.links);
-//prints ["www.linkedin.com"]
-println!("{:?}",parsed.emails);
-//prints ["associative@mail.com"]
-```   
+// prints ["5:00PM", "4:00"]
+println!("{:?}", parsed.phones);
+// prints ["(012)-345-6789"]
+println!("{:?}", parsed.links);
+// prints ["www.linkedin.com"]
+println!("{:?}", parsed.emails);
+// prints ["associative@mail.com"]
+```
 
 Alternatively, you can generate a single CommonRegex instance and use it to parse multiple segments of text.
-```
+```rust
 println!("{:?}",commonregex::times("When are you free? Do you want to meet up for coffee at 4:00?"));
 //prints ["4:00"]
 println!("{:?}",commonregex::prices("They said the price was $5,000.90, actually it is $3,900.5. It\'s $1100.4 less, can you imagine this?"));


### PR DESCRIPTION
The `[package]` section is canonically omitted.

Also take note that the (53MB in this case!) `target` directory is usually not present in the repository, too.